### PR TITLE
LPS-121077 Added use of start and end parameters to the AssetCategoryServiceImpl.search(long[] groupIds, String name, long[] vocabularyIds, int start, int end) method 

### DIFF
--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryServiceImpl.java
@@ -424,12 +424,12 @@ public class AssetCategoryServiceImpl extends AssetCategoryServiceBaseImpl {
 			if (Validator.isNull(name)) {
 				categoriesJSONArray = toJSONArray(
 					assetCategoryPersistence.filterFindByG_V(
-						groupId, vocabularyIds));
+						groupId, vocabularyIds, start, end));
 			}
 			else {
 				categoriesJSONArray = toJSONArray(
 					assetCategoryPersistence.filterFindByG_LikeN_V(
-						groupId, name, vocabularyIds));
+						groupId, name, vocabularyIds, start, end));
 			}
 
 			for (int j = 0; j < categoriesJSONArray.length(); j++) {


### PR DESCRIPTION
Added use of start and end parameters to the AssetCategoryServiceImpl.search(long[] groupIds, String name, long[] vocabularyIds, int start, int end) method
https://issues.liferay.com/browse/LPS-121077